### PR TITLE
Update manifest.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -57,7 +57,7 @@ volumes:
     type: pointer
     package-id: nextcloud
     volume-id: nextcloud
-    path: /data
+    path: /
     readonly: false
   cache: 
     type: data


### PR DESCRIPTION
This fixes a bug where a nextcloud install / reinstall can be broken by the existence of any directories.  It also allows for other users, notably an admin user who's username is not 'embassy'